### PR TITLE
fix: 日付など他の入力を変更した後に、何をする予定？のフォーカスが外れるようにする

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,8 @@ android {
 
     defaultConfig {
         applicationId "com.simple_reminder"
-        minSdkVersion flutter.minSdkVersion
+//        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 29
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/components/templates/create_remind.dart
+++ b/lib/components/templates/create_remind.dart
@@ -191,18 +191,26 @@ class _CreateRemindState extends State<CreateRemind> {
                   child: Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  Flexible(
+                  GestureDetector(
+                      onTap: () {
+                        // 日付など他の入力を変更した後にフォーカスが外れないため追加
+                        final currentScope = FocusScope.of(context);
+                        if (!currentScope.hasPrimaryFocus &&
+                            currentScope.hasFocus) {
+                          FocusManager.instance.primaryFocus?.unfocus();
+                        }
+                      },
                       child: TextField(
-                    maxLines: null,
-                    decoration: const InputDecoration(
-                      labelText: '何をする予定？',
-                    ),
-                    onChanged: (value) {
-                      setState(() {
-                        _title = value;
-                      });
-                    },
-                  )),
+                        maxLines: null,
+                        decoration: const InputDecoration(
+                          labelText: '何をする予定？',
+                        ),
+                        onChanged: (value) {
+                          setState(() {
+                            _title = value;
+                          });
+                        },
+                      )),
                   Row(
                     crossAxisAlignment: CrossAxisAlignment.end,
                     children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.1+2
+version: 1.0.2+3
 
 environment:
   sdk: ">=2.15.1 <3.0.0"


### PR DESCRIPTION
- 日付など入力後にフォーカスが当たったままとなり、UIに違和感が残るため